### PR TITLE
Bug in RedisServer driver when working with remote redis server

### DIFF
--- a/RedisServer.php
+++ b/RedisServer.php
@@ -158,23 +158,10 @@ class RedisServer implements IRedisServer
 			case '$':
 				if ($reply=='$-1') return null;
 				$response = null;
-				$read     = 0;
 				$size     = intval(substr($reply, 1));
 				if ($size > 0)
 				{
-					do
-					{
-						$block_size = min($size-$read, 4096);
-						if ($block_size < 1) break;
-						$data = fread($this->connection, $block_size);
-						if ($data===false)
-						{
-							$this->reportError('error when reading answer');
-							return false;
-						}
-						$response .= $data;
-						$read += $block_size;
-					} while ($read < $size);
+				    $response = stream_get_contents($this->connection, $size);
 				}
 				fread($this->connection, 2); /* discard crlf */
 				break;


### PR DESCRIPTION
It appears when working with remote redis server.
When reading response from socket and MTU is less than fread()'s $length argument, fread() according to the documentation returns the first packet and its size is less than 4096 bytes. So returning data becomes corrupted.
Possible solution is to decrease the reading block size to 1024 bytes or to use stream_get_contents() function.
