### PR TITLE
Add target-dir property so composer's autoloader works out of the box

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -20,6 +20,7 @@
 	},
 	"type": "library",
 	"license": "MIT",
+	"target-dir": "Jamm/Memory"
 	"authors": [
 		{
 			"name": "Eugene OZ",


### PR DESCRIPTION
Hi 
Seems to be a very nice lib!  (Altough haven't tested it well yet) 

As directory where the code namespce  begins name is different than src it would be nice to have  "target-dir": "Jamm/Memory"    in composer.json, like in pull-request
